### PR TITLE
fix(ci-cd): use token-bureau

### DIFF
--- a/.github/workflows/@workflows-src.yaml
+++ b/.github/workflows/@workflows-src.yaml
@@ -1,19 +1,28 @@
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   make:
     name: Convert to workflows
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: http://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
       - name: Checkout
         if: github.event_name == 'push'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          token: "${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}"
+          token: ${{ steps.token.outputs.token }}
           ref: ${{ github.event.push.ref }}
       - name: Checkout
         if: github.event_name == 'pull_request'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          token: "${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}"
+          token: ${{ steps.token.outputs.token }}
           ref: ${{ github.event.pull_request.head.ref }}
       - uses: "dhall-lang/setup-dhall@fedd8695a49579db7eca165c06ce47f62f7d5248"
         with:
@@ -25,7 +34,7 @@ jobs:
       - name: Clean up before commit
         run: rm -rf .cache bin share
       - env:
-          GITHUB_TOKEN: "${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}"
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         name: Commit changes
         uses: EndBug/add-and-commit@af39be11779239242ac2d3e47148221973246379
         with:

--- a/.github/workflows/boto.yml
+++ b/.github/workflows/boto.yml
@@ -3,6 +3,9 @@ name: Boto
 on:
   - issue_comment
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   Act:
     if: ${{ github.event.issue.pull_request }}
@@ -33,6 +36,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: http://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - name: Set up Node.js 14.x
         uses: actions/setup-node@v2-beta
         with:
@@ -52,7 +62,7 @@ jobs:
       - name: Checkout upstream repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          token: ${{ steps.token.outputs.token }}
           ref: ${{ steps.comment.outputs.branch }}
 
       - name: Get yarn cache directory path
@@ -97,7 +107,7 @@ jobs:
       - uses: EndBug/add-and-commit@v7
         env:
           HUSKY_SKIP_HOOKS: "true"
-          GITHUB_TOKEN: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:
           author_email: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}
           author_name: ${{ secrets.SOCIALGROOVYBOT_NAME }}
@@ -107,7 +117,7 @@ jobs:
       - name: Add success reaction
         uses: peter-evans/create-or-update-comment@v4
         with:
-          token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          token: ${{ steps.token.outputs.token }}
           comment-id: ${{ needs.Act.outputs.RUN_COMMENT_ID }}
           reaction-type: "+1"
 
@@ -115,6 +125,6 @@ jobs:
         if: failure()
         uses: peter-evans/create-or-update-comment@v4
         with:
-          token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          token: ${{ steps.token.outputs.token }}
           comment-id: ${{ needs.Act.outputs.RUN_COMMENT_ID }}
           reaction-type: "-1"


### PR DESCRIPTION
Migration vers le nouveau système "TokenBureau", le SOCIALGROOVYBOT_BOTO_PAT ne sera plus disponible à partir de février 2025, si vous voulez que vos workflows continuent à fonctionner correctement, vous devez merger cette PR.